### PR TITLE
use tag as title if not user provided fixes #26

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -137,6 +137,12 @@ func (p Plugin) Exec() error {
 		Note:       p.Config.Note,
 	}
 
+	// if the title was not provided via .drone.yml we use the tag instead
+	// fixes https://github.com/drone-plugins/drone-gitea-release/issues/26
+	if rc.Title == "" {
+		rc.Title = rc.Tag
+	}
+	
 	release, err := rc.buildRelease()
 
 	if err != nil {


### PR DESCRIPTION
Use the tag as title if it was not user provided via .drone.yml
I've pushed an image containing the fix to docker hub: pheelee/drone-gitea-release

```yaml
- name: publish-artifacts
  image: pheelee/drone-gitea-release
  settings:
    api_key: 
      from_secret: gitea_api_key
    base_url: https://***
    files: dist/*
```