### PR TITLE
🩹 Fix path in artifact name for windows upload

### DIFF
--- a/release.go
+++ b/release.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 
 	"code.gitea.io/sdk/gitea"
 )
@@ -86,12 +86,12 @@ func (rc *releaseClient) uploadFiles(releaseID int64, files []string) error {
 files:
 	for _, file := range files {
 		for _, attachment := range attachments {
-			if attachment.Name == path.Base(file) {
+			if attachment.Name == filepath.Base(file) {
 				switch rc.FileExists {
 				case "overwrite":
 					// do nothing
 				case "fail":
-					return fmt.Errorf("Asset file %s already exists", path.Base(file))
+					return fmt.Errorf("Asset file %s already exists", filepath.Base(file))
 				case "skip":
 					fmt.Printf("Skipping pre-existing %s artifact\n", attachment.Name)
 					continue files
@@ -112,7 +112,7 @@ files:
 		}
 
 		for _, attachment := range attachments {
-			if attachment.Name == path.Base(file) {
+			if attachment.Name == filepath.Base(file) {
 				if _, err := rc.Client.DeleteReleaseAttachment(rc.Owner, rc.Repo, releaseID, attachment.ID); err != nil {
 					return fmt.Errorf("Failed to delete %s artifact: %s", file, err)
 				}
@@ -121,7 +121,7 @@ files:
 			}
 		}
 
-		if _, _, err = rc.Client.CreateReleaseAttachment(rc.Owner, rc.Repo, releaseID, handle, path.Base(file)); err != nil {
+		if _, _, err = rc.Client.CreateReleaseAttachment(rc.Owner, rc.Repo, releaseID, handle, filepath.Base(file)); err != nil {
 			return fmt.Errorf("Failed to upload %s artifact: %s", file, err)
 		}
 

--- a/utils.go
+++ b/utils.go
@@ -10,6 +10,7 @@ import (
 	"hash/crc32"
 	"io"
 	"os"
+	"path/filepath"
 	"strconv"
 
 	"golang.org/x/crypto/blake2b"
@@ -70,7 +71,7 @@ func writeChecksums(files, methods []string) ([]string, error) {
 				return nil, err
 			}
 
-			checksums[method] = append(checksums[method], hash, file)
+			checksums[method] = append(checksums[method], hash, filepath.Base(file))
 		}
 	}
 


### PR DESCRIPTION
This fixes an issue where the path is part of the artifact name with artifacts uploaded from windows.
The cause was that [`path.Base` only works with `/`](https://pkg.go.dev/path#Base) while `filepath.Glob` returns paths with `\` on windows.

> Package path implements utility routines for manipulating slash-separated paths.

vs.

> Package filepath implements utility routines for manipulating filename paths in a way compatible with the target operating system-defined file paths.

I also applied this change to `writeChecksums` since having the original folder structure in the checksum file does not make sense when comparing it against the file on the release page.
