### PR TITLE
Allow publishing when tagged commits are promoted

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -50,9 +50,10 @@ type (
 func (p Plugin) Exec() error {
 	var (
 		files []string
+		tag   = strings.TrimPrefix(p.Commit.Ref, "refs/tags/")
 	)
 
-	if p.Build.Event != "tag" {
+	if tag == "" {
 		return fmt.Errorf("The Gitea Release plugin is only available for tags")
 	}
 
@@ -128,7 +129,7 @@ func (p Plugin) Exec() error {
 		Client:     client,
 		Owner:      p.Repo.Owner,
 		Repo:       p.Repo.Name,
-		Tag:        strings.TrimPrefix(p.Commit.Ref, "refs/tags/"),
+		Tag:        tag,
 		Draft:      p.Config.Draft,
 		Prerelease: p.Config.PreRelease,
 		FileExists: p.Config.FileExists,


### PR DESCRIPTION
### PR Description
Currently, this plugin throws an error whenever it gets executed as part of a pipeline outside the tag event.  

### Motivation
In my use case, I find it useful to produce a test build of my android app when a commit is tagged. After the build is tested, I would like to promote the tagged commit so that a production version of the app is built and signed.

This plugin does not allow the production build to be published to Gitea releases simply because the event that executed the pipeline is not a tag event, even though the commit is tagged just fine.

This PR is meant to address this issue
